### PR TITLE
Removed superfluous block overrides in pages

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -1,16 +1,5 @@
 {% extends "base.html" %}
 
-{% block navigation %}
-     <div class="navigation">
-        <ol class="nav">
-          <li><a href="{{ SITEURL }}">Blog</a> </li>
-          <li class="current"><a href="{{ SITEURL }}/archives.html">Archive</a></li>
-          <li><a href="{{ SITEURL }}/tags.html">Tags</a> </li>
-          <li><a href="{{ SITEURL }}/{{ FEED_RSS }}">RSS</a> </li>
-        </ol>
-      </div>
-{% endblock navigation %}
-
 {% block content %}
 <h2>Archives:</h2>
 

--- a/templates/article.html
+++ b/templates/article.html
@@ -1,14 +1,4 @@
 {% extends "base.html" %}
-{% block navigation %}
-     <div class="navigation">
-        <ol class="nav">
-          <li class="current"><a href="{{ SITEURL }}">Blog</a> </li>
-          <li><a href="{{ SITEURL }}/archives.html">Archive</a></li>
-          <li><a href="{{ SITEURL }}/tags.html">Tags</a> </li>
-          <li><a href="{{ FEED_RSS }}">RSS</a> </li>
-        </ol>
-      </div>
-{% endblock navigation %}  
 {% block content %}
 <section id="content" class="body">
   <header class="post">

--- a/templates/author.html
+++ b/templates/author.html
@@ -1,14 +1,4 @@
 {% extends "index.html" %}
-{% block navigation %}
-     <div class="navigation">
-        <ol class="nav">
-          <li><a href="{{ SITEURL }}">Blog</a> </li>
-          <li><a href="{{ SITEURL }}/archives.html">Archive</a></li>
-          <li><a href="{{ SITEURL }}/tags.html">Tags</a> </li>
-          <li><a href="{{ SITEURL }}/{{ FEED_RSS }}">RSS</a> </li>
-        </ol>
-      </div>
-    {% endblock navigation %}
 {% block title %}{{ SITENAME }} - Articles by {{ author }}{% endblock %}
 {% block content_title %}
 <h2>Articles by {{ author }}</h2>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,14 +1,4 @@
 {% extends "base.html" %}
-{% block navigation %}
-     <div class="navigation">
-        <ol class="nav">
-          <li class="current"><a href="{{ SITEURL }}">Blog</a> </li>
-          <li><a href="{{ SITEURL }}/archives.html">Archive</a></li>
-          <li><a href="{{ SITEURL }}/tags.html">Tags</a> </li>
-          <li><a href="{{ SITEURL }}/{{ FEED_RSS }}">RSS</a> </li>
-        </ol>
-      </div>
-{% endblock navigation %}
 {% block content %}        
 <section id="content">
 <div class="posts">

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,14 +1,4 @@
 {% extends "base.html" %}
-{% block navigation %}
-     <div class="navigation">
-        <ol class="nav">
-          <li><a href="{{ SITEURL }}">Blog</a> </li>
-          <li><a href="{{ SITEURL }}/archives.html">Archive</a></li>
-          <li><a href="{{ SITEURL }}/tags.html">Tags</a> </li>
-          <li><a href="{{ SITEURL }}/{{ FEED_RSS }}">RSS</a> </li>
-        </ol>
-      </div>
-    {% endblock navigation %}
 {% block title %}{{ page.title }}{%endblock%}
 {% block content %}
     <h2>{{ page.title }}</h2>

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -1,12 +1,2 @@
 {% extends "index.html" %}
-{% block navigation %}
-     <div class="navigation">
-        <ol class="nav">
-          <li><a href="{{ SITEURL }}">Blog</a> </li>
-          <li><a href="{{ SITEURL }}/archives.html">Archive</a></li>
-          <li class="current"><a href="{{ SITEURL }}/tags.html">Tags</a> </li>
-          <li><a href="{{ SITEURL }}/{{ FEED_RSS }}">RSS</a> </li>
-        </ol>
-      </div>
-{% endblock navigation %}
 {% block title %}{{ SITENAME }} <small>{{ tag }}</small>{% endblock %}

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -1,15 +1,5 @@
 {% extends "base.html" %}
 {% block title %}{{ SITENAME }} tags{% endblock %}
-{% block navigation %}
-     <div class="navigation">
-        <ol class="nav">
-          <li><a href="{{ SITEURL }}">Blog</a> </li>
-          <li><a href="{{ SITEURL }}/archives.html">Archive</a></li>
-          <li class="current"><a href="{{ SITEURL }}/tags.html">Tags</a> </li>
-          <li><a href="{{ SITEURL }}/{{ FEED_RSS }}">RSS</a> </li>
-        </ol>
-      </div>
-    {% endblock navigation %}
 {% block content %}
 <h2>Tags:</h2>
 <ul>


### PR DESCRIPTION
Since all pages extend the base.html template, the navigation block does
not need to be redefined in every page: since they were all the same, I
removed them.
